### PR TITLE
Add similarity utility for pronunciation scoring

### DIFF
--- a/lib/core/utils/similarity.dart
+++ b/lib/core/utils/similarity.dart
@@ -1,0 +1,66 @@
+/// Utility functions for computing similarity between strings.
+///
+/// The helpers in this file provide lightweight Levenshtein distance
+/// calculations and a normalised similarity score (0.0 - 1.0). These metrics
+/// are used by the pronunciation evaluation pipeline to provide feedback when
+/// offline.
+class Similarity {
+  /// Computes the Levenshtein edit distance between two strings.
+  ///
+  /// The implementation is intentionally iterative to avoid recursion overhead
+  /// and works with Unicode-safe `runes` by comparing code units.
+  static int levenshtein(String a, String b) {
+    if (identical(a, b) || a == b) {
+      return 0;
+    }
+    if (a.isEmpty) {
+      return b.length;
+    }
+    if (b.isEmpty) {
+      return a.length;
+    }
+
+    final rows = a.length + 1;
+    final cols = b.length + 1;
+    final matrix = List.generate(rows, (_) => List<int>.filled(cols, 0));
+
+    for (var i = 0; i < rows; i++) {
+      matrix[i][0] = i;
+    }
+    for (var j = 0; j < cols; j++) {
+      matrix[0][j] = j;
+    }
+
+    for (var i = 1; i < rows; i++) {
+      for (var j = 1; j < cols; j++) {
+        final cost = a.codeUnitAt(i - 1) == b.codeUnitAt(j - 1) ? 0 : 1;
+        final deletion = matrix[i - 1][j] + 1;
+        final insertion = matrix[i][j - 1] + 1;
+        final substitution = matrix[i - 1][j - 1] + cost;
+        final min = deletion < insertion
+            ? (deletion < substitution ? deletion : substitution)
+            : (insertion < substitution ? insertion : substitution);
+        matrix[i][j] = min;
+      }
+    }
+
+    return matrix[rows - 1][cols - 1];
+  }
+
+  /// Returns a normalised similarity score between 0.0 and 1.0.
+  ///
+  /// When both strings are empty the similarity is `1.0`, otherwise the score
+  /// is computed as `(maxLength - distance) / maxLength`.
+  static double normalizedScore(String a, String b) {
+    if (a.isEmpty && b.isEmpty) {
+      return 1;
+    }
+    final maxLength = a.length > b.length ? a.length : b.length;
+    if (maxLength == 0) {
+      return 1;
+    }
+    final distance = levenshtein(a, b).clamp(0, maxLength);
+    final score = (maxLength - distance) / maxLength;
+    return score.clamp(0, 1).toDouble();
+  }
+}

--- a/lib/data/repositories/speech_repository.dart
+++ b/lib/data/repositories/speech_repository.dart
@@ -5,6 +5,7 @@ import 'package:google_speech/google_speech.dart';
 
 import '../../core/errors/failure.dart';
 import '../../core/utils/either.dart';
+import '../../core/utils/similarity.dart';
 import '../../domain/entities/score_entity.dart';
 
 /// Contract for speech interactions.
@@ -45,39 +46,13 @@ class _SpeechRepositoryImpl implements SpeechRepository {
       _speechToTextClient.hashCode;
       final normalizedTarget = target.toLowerCase().trim();
       final normalizedTranscript = transcript.toLowerCase().trim();
-      final distance = _levenshtein(normalizedTarget, normalizedTranscript);
-      final maxLength = normalizedTarget.isEmpty ? 1 : normalizedTarget.length;
-      final accuracy = ((maxLength - distance) / maxLength).clamp(0, 1);
-      final score = (accuracy * 100).clamp(0, 100).toDouble();
+      final similarity = Similarity.normalizedScore(normalizedTarget, normalizedTranscript);
+      final score = (similarity * 100).clamp(0, 100).toDouble();
       final wpm = normalizedTranscript.split(' ').length / (4 / 60);
       return Right(ScoreEntity(itemId: target, score: score, wpm: wpm, timestamps: const []));
     } catch (error) {
       return Left(Failure('Unable to evaluate pronunciation', cause: error));
     }
-  }
-
-  int _levenshtein(String a, String b) {
-    if (a == b) return 0;
-    if (a.isEmpty) return b.length;
-    if (b.isEmpty) return a.length;
-    final matrix = List.generate(a.length + 1, (_) => List.filled(b.length + 1, 0));
-    for (var i = 0; i <= a.length; i++) {
-      matrix[i][0] = i;
-    }
-    for (var j = 0; j <= b.length; j++) {
-      matrix[0][j] = j;
-    }
-    for (var i = 1; i <= a.length; i++) {
-      for (var j = 1; j <= b.length; j++) {
-        final cost = a[i - 1] == b[j - 1] ? 0 : 1;
-        matrix[i][j] = [
-          matrix[i - 1][j] + 1,
-          matrix[i][j - 1] + 1,
-          matrix[i - 1][j - 1] + cost,
-        ].reduce((value, element) => value < element ? value : element);
-      }
-    }
-    return matrix[a.length][b.length];
   }
 }
 

--- a/test/unit/similarity_test.dart
+++ b/test/unit/similarity_test.dart
@@ -1,0 +1,36 @@
+import 'package:aura_plus/core/utils/similarity.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  group('Similarity.levenshtein', () {
+    test('returns zero for identical strings', () {
+      expect(Similarity.levenshtein('flutter', 'flutter'), 0);
+    });
+
+    test('handles empty strings', () {
+      expect(Similarity.levenshtein('', ''), 0);
+      expect(Similarity.levenshtein('aura', ''), 4);
+      expect(Similarity.levenshtein('', 'plus'), 4);
+    });
+
+    test('computes known distance for kitten vs sitting', () {
+      expect(Similarity.levenshtein('kitten', 'sitting'), 3);
+    });
+  });
+
+  group('Similarity.normalizedScore', () {
+    test('returns 1 for identical strings', () {
+      expect(Similarity.normalizedScore('hello', 'hello'), 1);
+    });
+
+    test('returns 0 when compared with empty string', () {
+      expect(Similarity.normalizedScore('hello', ''), 0);
+      expect(Similarity.normalizedScore('', 'hello'), 0);
+    });
+
+    test('returns value between 0 and 1 for partial matches', () {
+      final score = Similarity.normalizedScore('kitten', 'sitting');
+      expect(score, closeTo(4 / 7, 1e-6));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a reusable similarity helper that exposes Levenshtein distance and a normalised score
- use the shared utility when deriving pronunciation scores in the speech repository
- cover the similarity helper with focused unit tests

## Testing
- not run (flutter is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dfce0b80dc832bb9933e30a0f36a1f